### PR TITLE
Update image_selector_formfield.dart

### DIFF
--- a/lib/image_selector_formfield.dart
+++ b/lib/image_selector_formfield.dart
@@ -297,6 +297,10 @@ class __InkWidgetState extends State<_InkWidget> {
           : Image.file(_imageFile),
       onTap: () async {
         await getImage().then((imagen) {
+          // Guard against tapping native cancel button clearing a previously 
+          // picked and cropped avatar
+          if(imagen == null) return;
+          
           _imageFile = imagen;
           widget.setImage(imagen);
         });


### PR DESCRIPTION
Currently if you are

- on iOS
- pick & crop an avatar so it's shown in ImageSelectorFormField
- tap the widget so the native picker is shown
- press cancel on the top left of the native picker

Behavior: clears the previously picked & cropped avatar
Expected: returns to the app without clearing the previous avatar